### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   IMAGE_NAME: bsc
 


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bsc/security/code-scanning/3](https://github.com/roseteromeo56/bsc/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations (e.g., building and pushing Docker images), the following permissions are appropriate:
- `contents: read` to access repository contents.
- `packages: write` to push Docker images to GitHub Packages.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as the workflow does not define multiple jobs with differing permission requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
