### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/evm-tests.yml
+++ b/.github/workflows/evm-tests.yml
@@ -1,5 +1,8 @@
 name: EVM Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: 


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bsc/security/code-scanning/4](https://github.com/roseteromeo56/bsc/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, the minimal required permission is `contents: read`, which allows the workflow to read repository contents without granting write access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `evm-test` job. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
