### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,4 +1,6 @@
 name: Integration Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bsc/security/code-scanning/5](https://github.com/roseteromeo56/bsc/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Since the workflow only checks out code and runs tests, it only needs `contents: read` permissions. This ensures that the workflow does not have unnecessary write permissions.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
