### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nancy.yml
+++ b/.github/workflows/nancy.yml
@@ -1,5 +1,8 @@
 name: Go Nancy
 
+permissions:
+  contents: read
+
 on:
     # Scan changed files in PRs (diff-aware scanning):
     pull_request: {}


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bsc/security/code-scanning/7](https://github.com/roseteromeo56/bsc/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, it primarily reads repository contents, so we will set `contents: read`. If additional permissions are required in the future, they can be added explicitly.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
