### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - 'pre-*'
 
+permissions:
+  contents: read
+
 env:
   CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
   CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bsc/security/code-scanning/8](https://github.com/roseteromeo56/bsc/security/code-scanning/8)

To fix the issue, we need to explicitly define the permissions for the `GITHUB_TOKEN` in the workflow. Since the workflow involves operations like checking out code, uploading artifacts, downloading artifacts, and creating releases, we should assign the least privileges required for these tasks. 

The `contents: read` permission is sufficient for most basic CI workflows. Additional permissions like `contents: write` or `packages: write` should only be added if explicitly required by the workflow steps.

The permissions block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is appropriate since all jobs in the workflow interact with repository contents and artifacts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
