### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,5 +1,8 @@
 name: Unit Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: 


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bsc/security/code-scanning/10](https://github.com/roseteromeo56/bsc/security/code-scanning/10)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs basic CI tasks (installing dependencies, caching, and running unit tests), it only requires `contents: read` permissions. This change will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum required for the workflow.

The `permissions` block should be added at the root level of the workflow file, ensuring it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
