### PR TITLE
Potential fix for code scanning alert no. 29: Incomplete URL substring sanitization

### DIFF
--- a/BNB Chain Staking.html
+++ b/BNB Chain Staking.html
@@ -12,7 +12,7 @@
                       'https://www.googletagmanager.com/gtm.js?id=' +
                       i +
                       dl +
-                      (window.location.hostname.endsWith('bnbchain.org')
+                      (['bnbchain.org', 'www.bnbchain.org'].includes(window.location.hostname)
                         ? '&gtm_auth=yNIE-L06jPH-rS5Wug7Dxg&gtm_preview=env-1&gtm_cookies_win=x'
                         : '&gtm_auth=nbvRy1iQiFBIlgDWE8wJUA&gtm_preview=env-4&gtm_cookies_win=x');
                     f.parentNode.insertBefore(j, f);


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bsc/security/code-scanning/29](https://github.com/roseteromeo56/bsc/security/code-scanning/29)

To fix the issue, the hostname validation should be updated to ensure that only exact matches or specific subdomains of `'bnbchain.org'` are allowed. This can be achieved by maintaining a whitelist of allowed hostnames and checking against it. This approach eliminates the risk of arbitrary hostnames passing the validation.

**Steps to fix:**
1. Replace the `endsWith` check with a whitelist of allowed hostnames.
2. Use an array of allowed hostnames and check if `window.location.hostname` is included in this array.
3. Ensure the fix is implemented in the relevant script block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
