### PR TITLE
Potential fix for code scanning alert no. 24: Incorrect conversion between integer types

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -354,6 +354,9 @@ func parsePorts(portStr string, defaultPort int, size int) ([]int, error) {
 			if err != nil {
 				return nil, errors.New("invalid format of port")
 			}
+			if port < 0 || port > 65535 {
+				return nil, errors.New("port out of range (must be 0-65535)")
+			}
 			ports[i] = port
 		}
 	} else if len(portStr) != 0 {

--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -87,9 +87,15 @@ func NewV4(pubkey *ecdsa.PublicKey, ip net.IP, tcp, udp int) *Node {
 		r.Set(enr.IP(ip))
 	}
 	if udp != 0 {
+		if udp < 0 || udp > 65535 {
+			panic(fmt.Sprintf("invalid UDP port: %d (must be 0-65535)", udp))
+		}
 		r.Set(enr.UDP(udp))
 	}
 	if tcp != 0 {
+		if tcp < 0 || tcp > 65535 {
+			panic(fmt.Sprintf("invalid TCP port: %d (must be 0-65535)", tcp))
+		}
 		r.Set(enr.TCP(tcp))
 	}
 	signV4Compat(&r, pubkey)


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bsc/security/code-scanning/24](https://github.com/roseteromeo56/bsc/security/code-scanning/24)

To fix the issue, we need to ensure that the integer values passed to `enr.TCP` and `enr.UDP` are within the valid range for `uint16` (0 to 65535). This can be achieved by adding explicit bounds checks in the `NewV4` function in `p2p/enode/urlv4.go`. If the values are out of range, the function should either return an error or use a default value.

Additionally, the `parsePorts` function in `cmd/geth/chaincmd.go` should also validate that the parsed port numbers are within the `uint16` range to prevent invalid data from propagating further.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
