### PR TITLE
Potential fix for code scanning alert no. 22: Incorrect conversion between integer types

### DIFF
--- a/cmd/devp2p/discv4cmd.go
+++ b/cmd/devp2p/discv4cmd.go
@@ -336,7 +336,7 @@ func parseExtAddr(spec string) (ip net.IP, port int, ok bool) {
 		return nil, 0, false
 	}
 	port, err = strconv.Atoi(portstr)
-	if err != nil {
+	if err != nil || port < 0 || port > 65535 {
 		return nil, 0, false
 	}
 	return ip, port, true

--- a/p2p/enode/localnode.go
+++ b/p2p/enode/localnode.go
@@ -205,6 +205,10 @@ func (ln *LocalNode) SetFallbackIP(ip net.IP) {
 // SetFallbackUDP sets the last-resort UDP-on-IPv4 port. This port is used
 // if no endpoint prediction can be made.
 func (ln *LocalNode) SetFallbackUDP(port int) {
+	if port < 0 || port > 65535 {
+		log.Error("SetFallbackUDP: port out of range", "port", port)
+		return
+	}
 	ln.mu.Lock()
 	defer ln.mu.Unlock()
 


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bsc/security/code-scanning/22](https://github.com/roseteromeo56/bsc/security/code-scanning/22)

To fix the issue, we need to ensure that the `port` value is validated before converting it to `uint16`. Specifically:
1. Add bounds checking to ensure the `port` value is within the valid range for `uint16` (0 to 65535).
2. If the value is out of bounds, handle the error gracefully (e.g., by logging an error or using a default value).

The changes will be made in both `cmd/devp2p/discv4cmd.go` (where the `port` is parsed) and `p2p/enode/localnode.go` (where the conversion occurs).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
