### PR TITLE
Potential fix for code scanning alert no. 18: Incorrect conversion between integer types

### DIFF
--- a/beacon/fakebeacon/api_func.go
+++ b/beacon/fakebeacon/api_func.go
@@ -3,6 +3,8 @@ package fakebeacon
 import (
 	"context"
 	"sort"
+	"math"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
@@ -49,6 +51,10 @@ func beaconGenesis() APIGenesisResponse {
 
 func beaconBlobSidecars(ctx context.Context, backend ethapi.Backend, slot uint64, indices []int) (APIGetBlobSidecarsResponse, error) {
 	var blockNrOrHash rpc.BlockNumberOrHash
+	if slot > uint64(math.MaxInt64) {
+		log.Error("Slot value exceeds int64 range", "slot", slot)
+		return APIGetBlobSidecarsResponse{}, fmt.Errorf("slot value exceeds int64 range")
+	}
 	header, err := fetchBlockNumberByTime(ctx, int64(slot), backend)
 	if err != nil {
 		log.Error("Error fetching block number", "slot", slot, "indices", indices)


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bsc/security/code-scanning/18](https://github.com/roseteromeo56/bsc/security/code-scanning/18)

To fix the issue, we need to ensure that the `slot` value is within the valid range of `int64` before performing the conversion. This can be achieved by adding a bounds check for `slot` against `math.MaxInt64`. If the value exceeds the maximum allowable range, we should handle it appropriately (e.g., return an error or use a default value).

Changes to be made:
1. Add an import for the `math` package in `api_func.go`.
2. Add a bounds check for `slot` before converting it to `int64` in `api_func.go`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
