### PR TITLE
Potential fix for code scanning alert no. 19: Incorrect conversion between integer types

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -463,6 +463,10 @@ func inspectTrie(ctx *cli.Context) error {
 			if err != nil {
 				return fmt.Errorf("failed to parse topn, Args[1]: %v, err: %v", ctx.Args().Get(1), err)
 			}
+			// Ensure topN is within the valid range of int
+			if topN > uint64(math.MaxInt) {
+				return fmt.Errorf("topn value out of range, Args[1]: %v", ctx.Args().Get(1))
+			}
 		}
 
 		if blockNumber != math.MaxUint64 {


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bsc/security/code-scanning/19](https://github.com/roseteromeo56/bsc/security/code-scanning/19)

To fix the issue, we need to ensure that the value of `topN` is within the valid range of the `int` type before performing the conversion. This can be achieved by adding an upper bound check against `math.MaxInt` (the maximum value of the `int` type) and a lower bound check to ensure the value is non-negative. If the value is out of bounds, the program should handle it appropriately, such as by returning an error or using a default value.

The changes will be made in the `cmd/geth/dbcmd.go` file:
1. Add bounds checking for `topN` after parsing it with `strconv.ParseUint`.
2. Ensure that the conversion to `int` is only performed if the value is within the valid range.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
